### PR TITLE
Update hf_decoder_model.py

### DIFF
--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -162,7 +162,6 @@ class HFDecoderModel(DecoderModel, Tunable):
                     task_type=TaskType.CAUSAL_LM,
                     inference_mode=False,
                     r=model_args.lora_r,
-                    target_modules=["q_proj","v_proj"],
                     lora_alpha=model_args.lora_alpha,
                     lora_dropout=model_args.lora_dropout
                 )


### PR DESCRIPTION
remove explicit `target_modules`; PEFT would detect it automatically.