### PR TITLE
Support ppl as one of the evaluation metrics and fix bug for llama offload loading

### DIFF
--- a/examples/evaluate.py
+++ b/examples/evaluate.py
@@ -40,4 +40,7 @@ evaluator = AutoPipeline.get_pipeline(
     data_args=data_args,
     pipeline_args=pipeline_args,
 )
-evaluator.evaluate(model=model, dataset=dataset)
+# Demo for evaluating accuracy(default)
+# evaluator.evaluate(model=model, dataset=dataset, metric='acc')
+# Demo for evaluating ppl
+evaluator.evaluate(model=model, dataset=dataset, metric='ppl')

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -447,7 +447,15 @@ class EvaluatorArguments:
             )
         },
     )
-
+    evaluate_block_size: Optional[int] = field(
+        default=512,
+        metadata={
+            "help": (
+                "the model will have at least block_size tokens for context when calculating the conditional likelihood of any one token"
+                " (provided there are block_size preceding tokens available to condition on)"
+            )
+        },
+    )
 
 @dataclass
 class InferencerArguments:

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -185,6 +185,13 @@ class HFDecoderModel(DecoderModel, Tunable):
         elif tune_strategy == 'none':
             dschf = HfDeepSpeedConfig(ds_config)
             peft_model_id = model_args.lora_model_path
+            # NOTE: Currently offload is not supported by llama
+            if "llama" in model_args.model_name_or_path and model_args.use_ram_optimized_load:
+                logger.warning(
+                    "llama does not support RAM optimized load. Automatically"
+                    " use original load instead."
+                )
+                model_args.use_ram_optimized_load = False
 
             if model_args.use_ram_optimized_load and peft_model_id is None:
                 try:

--- a/src/lmflow/pipeline/evaluator.py
+++ b/src/lmflow/pipeline/evaluator.py
@@ -227,7 +227,6 @@ class Evaluator(BasePipeline):
         nlls = []
         prev_end_loc = 0
         for begin_loc in range(0, seq_len, stride):
-            print(begin_loc)
             end_loc = min(begin_loc + max_length, seq_len)
             trg_len = end_loc - prev_end_loc  # may be different from stride on last loop
             input_ids = encodings.input_ids[:, begin_loc:end_loc].to(device=self.local_rank)
@@ -243,8 +242,8 @@ class Evaluator(BasePipeline):
 
             nlls.append(neg_log_likelihood)
             prev_end_loc = end_loc
+            print(f"Evaluating PPL: {int(begin_loc/stride) + 1} / {int(seq_len/stride)} Complete, current ppl : {torch.exp(torch.stack(nlls).mean())}")
             if end_loc == seq_len:
                 break
-            print(f"begin_loc:{begin_loc}")
         ppl = torch.exp(torch.stack(nlls).mean())
-        print(f"ppl: {ppl}")
+        print(f"Final ppl: {ppl}")

--- a/src/lmflow/pipeline/evaluator.py
+++ b/src/lmflow/pipeline/evaluator.py
@@ -225,9 +225,10 @@ class Evaluator(BasePipeline):
         encodings = model.get_tokenizer()("\n\n".join(texts), return_tensors="pt")
         # Define some constant
         try:
-            max_length = model.get_backend_model().config.n_positions
+            max_length = min(model.get_backend_model().config.n_positions, model.get_max_length())
         except:
-            max_length = 1024
+            max_length = min(1024, model.get_max_length())
+        
         print(f"The maximum sequence length : {max_length}")
         seq_len = encodings.input_ids.size(1)
 

--- a/src/lmflow/pipeline/evaluator.py
+++ b/src/lmflow/pipeline/evaluator.py
@@ -125,7 +125,7 @@ class Evaluator(BasePipeline):
             
 
         """
-        if(metric == "accuracy"):
+        if metric == "accuracy":
             dataloader, data_size = self.create_dataloader(dataset)
 
             if not dist.is_initialized() or dist.get_rank() == 0:
@@ -211,7 +211,7 @@ class Evaluator(BasePipeline):
                 current_accuracy = np.mean(acc_list)
                 print("Final accuracy = ", current_accuracy)
                 output_writer.close()
-        elif(metric == "ppl"):
+        elif metric == "ppl":
             ppl =  self._evaluate_ppl(model, dataset)
             print(f"Evaluating final ppl: {ppl}")
         else:


### PR DESCRIPTION
- add ppl evaluation as one metric of evaluate function of Evaluator.
- some statistic for reference(wikitext-2-raw-v1 data and RTX 3090) : ppl for gpt2, gpt2-large, got-neo2.7B, original LLaMA and LLaMA + LoRA-380k are 25.3, 16.4, 13, 5.3, 5.6 respectively .
- fix a bug which will lead to copy meta tensor, no data error : ram optimised offload seems currently not supported by LLaMA (no matter LoRA), so we currently automatically convert to original loading without offloading for LLaMA.