### PR TITLE
fix evaluator

### DIFF
--- a/src/lmflow/pipeline/evaluator.py
+++ b/src/lmflow/pipeline/evaluator.py
@@ -221,7 +221,10 @@ class Evaluator(BasePipeline):
 
     def _evaluate_ppl(self, model, dataset: Dataset):
         data_dict = dataset.to_dict()
-        texts = [ instance["text"] for instance in data_dict["instances"] ]
+        if data_dict['type'] == 'text2text':
+            texts = [ instance["input"] for instance in data_dict["instances"] ]
+        elif data_dict['type'] == 'text_only':
+            texts = [ instance["text"] for instance in data_dict["instances"] ]
         encodings = model.get_tokenizer()("\n\n".join(texts), return_tensors="pt")
         # Define some constant
         try:


### PR DESCRIPTION
The evaluator.py can not handle different file types for val data and train data. I add the if condition based on the file type. 
<img width="335" alt="image" src="https://user-images.githubusercontent.com/47224289/230755165-301968ce-91ff-4af7-9bb4-9df3541993a2.png">
<img width="312" alt="image" src="https://user-images.githubusercontent.com/47224289/230755181-31321f27-c6c7-470e-9dbd-a47daebaf04f.png">
