### PR TITLE
Bug Fix: restrict dataset type for ppl evaluation

### DIFF
--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -467,7 +467,7 @@ class EvaluatorArguments:
         },
     )
     metric: Optional[str] = field(
-        default="ppl",
+        default="accuracy",
         metadata={
             "help": "the metric the model will be evaluated on",
             "choices": ["ppl", "accuracy"],

--- a/src/lmflow/pipeline/evaluator.py
+++ b/src/lmflow/pipeline/evaluator.py
@@ -221,6 +221,8 @@ class Evaluator(BasePipeline):
 
     def _evaluate_ppl(self, model, dataset: Dataset):
         data_dict = dataset.to_dict()
+        if data_dict['type'] == 'text2text':
+            raise NotImplementedError("ppl evaluation is currently not supported for text2text dataset, please use text_only dataset.")
         texts = [ instance["text"] for instance in data_dict["instances"] ]
         encodings = model.get_tokenizer()("\n\n".join(texts), return_tensors="pt")
         # Define some constant


### PR DESCRIPTION
- check datatype before do ppl evaluation
- set the default evaluation metric to accuracy, as it is the most common metric used