### PR TITLE
LoRA-layer-support

### DIFF
--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -13,7 +13,7 @@ extracted from the MODEL_CONFIG_CLASSES.
 """
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, List
 
 from transformers.utils.versions import require_version
 
@@ -171,9 +171,9 @@ class ModelArguments:
         default=32,
         metadata={"help": "Merging ratio between the fine-tuned model and the original. This is controlled by a parameter called alpha in the paper."},
     )
-    lora_target_modules: Optional[list] = field(
-        default=[], metadata={"help": "Pretrained config name or path if not the same as model_name",
-                              "nargs": "+"}
+    lora_target_modules: List[str] = field(
+        default=None, metadata={"help": "Pretrained config name or path if not the same as model_name",
+                              }
     )
     lora_dropout: float = field(
         default=0.1,

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -171,6 +171,9 @@ class ModelArguments:
         default=32,
         metadata={"help": "Merging ratio between the fine-tuned model and the original. This is controlled by a parameter called alpha in the paper."},
     )
+    lora_target_modules: Optional[str] = field(
+        default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
+    )
     lora_dropout: float = field(
         default=0.1,
         metadata={"help": "The dropout rate in lora.linear."},

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -171,8 +171,8 @@ class ModelArguments:
         default=32,
         metadata={"help": "Merging ratio between the fine-tuned model and the original. This is controlled by a parameter called alpha in the paper."},
     )
-    lora_target_modules: Optional[str] = field(
-        default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
+    lora_target_modules: Optional[list] = field(nargs='+',
+        default=[], metadata={"help": "Pretrained config name or path if not the same as model_name"}
     )
     lora_dropout: float = field(
         default=0.1,

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -171,8 +171,9 @@ class ModelArguments:
         default=32,
         metadata={"help": "Merging ratio between the fine-tuned model and the original. This is controlled by a parameter called alpha in the paper."},
     )
-    lora_target_modules: Optional[list] = field(nargs='+',
-        default=[], metadata={"help": "Pretrained config name or path if not the same as model_name"}
+    lora_target_modules: Optional[list] = field(
+        default=[], metadata={"help": "Pretrained config name or path if not the same as model_name",
+                              "nargs": "+"}
     )
     lora_dropout: float = field(
         default=0.1,

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -164,7 +164,8 @@ class HFDecoderModel(DecoderModel, Tunable):
             self.backend_model_full = model
             if model_args.use_lora:
                 if model_args.lora_target_modules:
-                    lora_target_modules = eval(model_args.lora_target_modules)
+                    lora_target_modules = model_args.lora_target_modules
+                    print(model_args.lora_target_modules)
                 else:
                     lora_target_modules = None
                 peft_config = LoraConfig(

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -165,7 +165,6 @@ class HFDecoderModel(DecoderModel, Tunable):
             if model_args.use_lora:
                 if model_args.lora_target_modules:
                     lora_target_modules = model_args.lora_target_modules
-                    print(model_args.lora_target_modules)
                 else:
                     lora_target_modules = None
                 peft_config = LoraConfig(

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -163,13 +163,17 @@ class HFDecoderModel(DecoderModel, Tunable):
                 logger.info(f"Training new model from scratch - Total size={n_params/2**20:.2f}M params")
             self.backend_model_full = model
             if model_args.use_lora:
-                
+                if model_args.lora_target_modules:
+                    lora_target_modules = eval(lora_target_modules)
+                else:
+                    lora_target_modules = None
                 peft_config = LoraConfig(
                     task_type=TaskType.CAUSAL_LM,
                     inference_mode=False,
                     r=model_args.lora_r,
                     lora_alpha=model_args.lora_alpha,
-                    lora_dropout=model_args.lora_dropout
+                    lora_dropout=model_args.lora_dropout,
+                    target_modules=lora_target_modules,
                 )
                 model = get_peft_model(model, peft_config)
                 model.print_trainable_parameters()

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -164,7 +164,7 @@ class HFDecoderModel(DecoderModel, Tunable):
             self.backend_model_full = model
             if model_args.use_lora:
                 if model_args.lora_target_modules:
-                    lora_target_modules = eval(lora_target_modules)
+                    lora_target_modules = eval(model_args.lora_target_modules)
                 else:
                     lora_target_modules = None
                 peft_config = LoraConfig(


### PR DESCRIPTION
Support diy lora_target_modules layer.
For example, for LLaMA, you can use `--lora_target_modules q_proj k_proj v_proj o_proj` for more layers.