### PR TITLE
Fix text2text nll

### DIFF
--- a/configs/ds_config_eval.json
+++ b/configs/ds_config_eval.json
@@ -1,0 +1,11 @@
+{
+    "fp16": {
+        "enabled": false
+    },
+    "bf16": {
+        "enabled": false
+    },
+    "steps_per_print": 2000,
+    "train_micro_batch_size_per_gpu": 1,
+    "wall_clock_breakdown": false
+}

--- a/src/lmflow/datasets/__init__.py
+++ b/src/lmflow/datasets/__init__.py
@@ -4,4 +4,4 @@ and manipulating datasets from different backends such as Hugging Face and JSON.
 The `Dataset` class includes methods for loading datasets from a dictionary and a Hugging
 Face dataset, mapping datasets, and retrieving the backend dataset and arguments.
 """
-from datasets import Dataset
+from lmflow.datasets.dataset import Dataset

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -105,6 +105,7 @@ class HFDecoderModel(DecoderModel, Tunable):
         # only one local process can concurrently download model & vocab.
 
         self.device = device
+        self.model_args = model_args
 
         if tune_strategy == 'normal':
             config_kwargs = {
@@ -181,7 +182,6 @@ class HFDecoderModel(DecoderModel, Tunable):
             if len(tokenizer) > embedding_size:
                 model.resize_token_embeddings(len(tokenizer))
 
-            self.model_args = model_args
             self.config = config
             self.backend_model = model
             self.tokenizer = tokenizer

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -242,7 +242,7 @@ class HFDecoderModel(DecoderModel, Tunable):
             raise NotImplementedError('adapter tune strategy not implemented')
 
 
-    def tokenize(self, dataset, *args, **kwargs):
+    def tokenize(self, dataset, add_special_tokens=True, *args, **kwargs):
         """
         Tokenize the full dataset.
     
@@ -259,7 +259,9 @@ class HFDecoderModel(DecoderModel, Tunable):
         Returns
         ------------
         tokenized_datasets :
-            The tokenized dataset.
+            The tokenized dataset, without any leading or trailing special
+            tokens (normally they are Begin-Of-Sentence or End-Of-Sentence
+            tokens).
         """
         # Preprocessing the datasets.
         # First we tokenize all the texts.
@@ -317,6 +319,7 @@ class HFDecoderModel(DecoderModel, Tunable):
                 for column_name in tokenized_column_order:
                     encoding = self.tokenizer(
                         examples[column_name],
+                        add_special_tokens=add_special_tokens,
                         truncation=True if model_args.use_lora else None,
                     )
 

--- a/src/lmflow/pipeline/evaluator.py
+++ b/src/lmflow/pipeline/evaluator.py
@@ -290,7 +290,8 @@ class Evaluator(BasePipeline):
             ]
 
         dataset = dataset.from_dict(data_dict)
-        tokenized_dataset = model.tokenize(dataset).get_backend_dataset()
+        tokenized_dataset = model.tokenize(dataset, add_special_tokens=False)
+        tokenized_dataset = tokenized_dataset.get_backend_dataset()
         encoding_list = [
             {
                 "input_ids": torch.tensor([input_ids]),


### PR DESCRIPTION
Fix text2text nll

- Take sequence length into account
- Sequence length -= 1 if first token is not -100 (since in transformers the first token is ignored, e.g. [gpt2](https://github.com/huggingface/transformers/blob/15641892985b1d77acc74c9065c332cd7c3f7d7f/src/transformers/models/gpt2/modeling_gpt2.py#L1105).
- Fix dataset import problem in `src/lmflow/datasets/__init__.py`
- Fix unfair comparison between models caused by `add_special_tokens`
- Add input/output/full nll printing for "text2text" typed dataset

Currently this metric can only be used to roughly compare model quality. If model quality has huge difference, this metric can reflect the quality gap. Otherwise, the comparison may be meaningless. Some metrics are shown as a reference (in our hold-out dataset which contains 50 Chinese and 50 English samples):

|  model   | text2text nll  |
|  ----  | ----  |
| gpt2  | 702 |
| gpt2-large  | 580 |
| gpt2-xl | 556 |
| facebook/galactica-1.3b  | 506 |
| EleutherAI/gpt-neo-2.7B | 350 |
| OptimalScale/gpt-neo2.7B-inst-tuning | 312 |
| llama-7b | 300 |
| vicuna-7b | 288 |