### PR TITLE
Fix bugs of runtime evaluation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ flask
 flask_cors
 icetk
 cpm_kernels==1.0.11
+evaluate==0.4.0
+scikit-learn==1.2.2

--- a/scripts/run_finetune_with_lora_save_aggregated_weights.sh
+++ b/scripts/run_finetune_with_lora_save_aggregated_weights.sh
@@ -12,7 +12,7 @@ output_dir=${project_dir}/output_models/${exp_id}
 log_dir=${project_dir}/log/${exp_id}
 
 dataset_path=${project_dir}/data/alpaca/train
-eval_dataset_path=${project_dir}/data/eval/
+eval_dataset_path=${project_dir}/data/alpaca/test
 
 mkdir -p ${output_dir} ${log_dir}
 
@@ -35,7 +35,7 @@ deepspeed ${deepspeed_args} \
     --logging_steps 20 \
     --do_train \
     --do_eval \
-    --eval_strategy "steps" \
+    --evaluation_strategy "steps" \
     --eval_steps 1000 \
     --eval_dataset_path ${eval_dataset_path} \
     --ddp_timeout 72000 \


### PR DESCRIPTION
- Add missing dependency
- Use `data/alpha/test` as the evaluation set for `run_finetune_with_lora_save_aggregated_weights.sh`, so it is available to our users.
- Fix typo: evaluation_strategy -> eval_strategy