### PR TITLE
Fix RAFT: dataset type "float_only" support

### DIFF
--- a/src/lmflow/datasets/dataset.py
+++ b/src/lmflow/datasets/dataset.py
@@ -22,12 +22,14 @@ from lmflow.utils.constants import (
     DATASET_DESCRIPTION_MAP,
     TEXT_ONLY_DATASET_DESCRIPTION,
     TEXT2TEXT_DATASET_DESCRIPTION,
+    FLOAT_ONLY_DATASET_DESCRIPTION,
     INSTANCE_FIELDS_MAP,
 )
 
 DATASET_TYPES = [
     "text_only",
     "text2text",
+    "float_only",
 ]
 
 KEY_TYPE = "type"

--- a/src/lmflow/utils/constants.py
+++ b/src/lmflow/utils/constants.py
@@ -132,6 +132,22 @@ TEXT2TEXT_DATASET_DETAILS = (
 ).lstrip("\n")
 
 
+FLOAT_ONLY_DATASET_DESCRIPTION = (
+"""
+"float_only": a dataset with only float instances, with following format:
+
+    {
+        "type": "float_only",
+        "instances": [
+            { "value": "FLOAT_1" },
+            { "value": "FLOAT_2" },
+            ...
+        ]
+    }
+"""
+).lstrip("\n")
+
+
 TEXT_ONLY_DATASET_LONG_DESCRITION = (
     TEXT_ONLY_DATASET_DESCRIPTION + TEXT_ONLY_DATASET_DETAILS
 )
@@ -144,9 +160,11 @@ TEXT2TEXT_DATASET_LONG_DESCRITION = (
 DATASET_DESCRIPTION_MAP = {
     "text_only": TEXT_ONLY_DATASET_DESCRIPTION,
     "text2text": TEXT2TEXT_DATASET_DESCRIPTION,
+    "float_only": FLOAT_ONLY_DATASET_DESCRIPTION,
 }
 
 INSTANCE_FIELDS_MAP = {
     "text_only": ["text"],
     "text2text": ["input", "output"],
+    "float_only": ["value"],
 }


### PR DESCRIPTION
- Add type check support for "float_only"