### PR TITLE
Add dependency `dill<0.3.5`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ cpm_kernels==1.0.11
 evaluate==0.4.0
 scikit-learn==1.2.2
 lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git#egg=lm-eval-0.3.0
+dill<0.3.5


### PR DESCRIPTION
It has been observed that huggingface fingerprint update sometimes causes huge memory consumption and results to OOM. This problem doesn't occur with `dill<0.3.5` and can be fixed by installing this dependency.