### PR TITLE
Update SD256-RAFT.ipynb

### DIFF
--- a/experimental/RAFT-diffusion/SD256-RAFT.ipynb
+++ b/experimental/RAFT-diffusion/SD256-RAFT.ipynb
@@ -52,7 +52,7 @@
       "source": [
         "#@title Install CLIP\n",
         "\n",
-        "!pip install git+https://github.com/openai/CLIP.git"
+        "!pip install git+https://github.com/deepgoyal19/CLIP.git"
       ]
     },
     {


### PR DESCRIPTION
 The current version of CLIP installs a different version of PyTorch along with it. However, that PyTorch version is not compatible with our code. Therefore, I have forked the CLIP repository and made some changes to ensure it can work with our code.