### PR TITLE
Update SD256-RAFT.ipynb

### DIFF
--- a/experimental/RAFT-diffusion/SD256-RAFT.ipynb
+++ b/experimental/RAFT-diffusion/SD256-RAFT.ipynb
@@ -35,8 +35,7 @@
       "outputs": [],
       "source": [
         "#@title Install the required libs\n",
-        "%pip install -U -qq git+https://github.com/huggingface/diffusers.git\n",
-        "%pip install -q accelerate transformers ftfy bitsandbytes gradio natsort safetensors xformers datasets\n",
+        "%pip install -q accelerate diffusers transformers ftfy bitsandbytes gradio natsort safetensors xformers datasets\n",
         "%pip install -qq \"ipywidgets>=7,<8\"\n",
         "!wget -q https://raw.githubusercontent.com/OptimalScale/LMFlow/main/experimental/RAFT-diffusion/train_text_to_image_lora.py"
       ]


### PR DESCRIPTION
The comand below installs the diffusers version 0.17.0+dev0 which is creating problems during inference.
```python
%pip install -U -qq git+https://github.com/huggingface/diffusers.git
```

Now the proposed change will install diffusers version 0.16.1, which will resolve the problems we are experiencing with the current version (0.17.0+dev0).