### PR TITLE
fix_inferency.py

### DIFF
--- a/src/lmflow/pipeline/inferencer.py
+++ b/src/lmflow/pipeline/inferencer.py
@@ -140,7 +140,7 @@ class Inferencer(BasePipeline):
 
             outputs = model.inference(
                 inputs,
-                max_new_tokens=self.inferencer_args.max_new_tokens,
+                max_new_tokens=max_new_tokens,
                 temperature=self.inferencer_args.temperature,
                 repetition_penalty=self.inferencer_args.repetition_penalty,
                 do_sample=self.inferencer_args.do_sample,


### PR DESCRIPTION
 using `max_new_tokens=self.inferencer_args.max_new_tokens` will make stream_inference useless