### PR TITLE
Disable text grouping

### DIFF
--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -414,6 +414,19 @@ class HFDecoderModel(DecoderModel, Tunable):
                         )
                         token_dict["labels"][i].extend(labels[i])
 
+            # artificial pad to max_length
+            if data_args.disable_group_texts:
+                for i in range(num_example):
+                    token_dict["input_ids"][i].extend(
+                        [self.tokenizer.pad_token_id for _ in range(data_args.block_size-len(token_dict["input_ids"][i]))]
+                    )
+                    token_dict["attention_mask"][i].extend(
+                        [0 for _ in range(data_args.block_size-len(token_dict["attention_mask"][i]))]
+                    )
+                    token_dict["labels"][i].extend(
+                        [-100 for _ in range(data_args.block_size-len(token_dict["labels"][i]))]
+                    )
+
             # clm input could be much much longer than block_size
             if "Token indices sequence length is longer than the" in cl.out:
                 tok_logger.warning(

--- a/src/lmflow/pipeline/finetuner.py
+++ b/src/lmflow/pipeline/finetuner.py
@@ -208,10 +208,13 @@ class Finetuner(BaseTuner):
         # Tokenization and text grouping must be done in the main process
         with finetuner_args.main_process_first(desc="dataset map tokenization"):
             tokenized_dataset = model.tokenize(dataset)
-            lm_dataset = self.group_text(
-                tokenized_dataset,
-                model_max_length=model.get_max_length(),
-            )
+            if data_args.disable_group_texts:
+                lm_dataset = tokenized_dataset
+            else:
+                lm_dataset = self.group_text(
+                    tokenized_dataset,
+                    model_max_length=model.get_max_length(),
+                )
 
         train_dataset = lm_dataset.get_backend_dataset()
 
@@ -221,10 +224,13 @@ class Finetuner(BaseTuner):
             eval_dataset = Dataset(eval_dataset_args)
             with finetuner_args.main_process_first(desc="dataset map tokenization"):
                 tokenized_dataset = model.tokenize(eval_dataset)
-                lm_dataset = self.group_text(
-                    tokenized_dataset,
-                    model_max_length=model.get_max_length(),
-                )
+                if data_args.disable_group_texts:
+                    lm_dataset = tokenized_dataset
+                else:
+                    lm_dataset = self.group_text(
+                        tokenized_dataset,
+                        model_max_length=model.get_max_length(),
+                    )
             eval_dataset = lm_dataset.get_backend_dataset()
 
 


### PR DESCRIPTION
As discussed in #562 , text grouping should be disabled for text2text training by default.

However, while setting the argument --disable_group_texts, their would be a bug as described in #96. And referring to #538 , the bug has not been fixed in recent versions. So I modify the codes a little bit to support disable_group_texts.

In my modified version, if --disable_group_texts is set as True, then the text_grouping would be skipped (and the dataset would be manually padded to the maximum length or block size to support batching).