### PR TITLE
Added QLoRA support for Decoder transformers with tune_strategy "Normal"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ torch==2.0.0
 wandb==0.14.0
 deepspeed==0.8.3
 trl
-sentencepiece
+sentencepiece==0.1.99
 transformers>=4.31.0
 flask
 flask_cors
@@ -18,3 +18,6 @@ dill<0.3.5
 bitsandbytes>=0.40.0
 pydantic<=1.10.9
 gradio
+accelerate>=0.21.0
+einops>=0.6.1
+scikit-learn==1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 numpy==1.24.2
 datasets==2.10.1
+tokenizers==0.13.3
 peft>=0.4.0
-torch>=2.0.0
+torch==2.0.1
 wandb==0.14.0
-deepspeed==0.8.3
+deepspeed
 trl
 sentencepiece==0.1.99
 transformers>=4.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.24.2
 datasets==2.10.1
 peft>=0.4.0
-torch==2.0.0
+torch>=2.0.0
 wandb==0.14.0
 deepspeed==0.8.3
 trl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 numpy==1.24.2
 datasets==2.10.1
-peft @ git+https://github.com/huggingface/peft.git@deff03f2c251534fffd2511fc2d440e84cc54b1b
+peft>=0.4.0
 torch==2.0.0
 wandb==0.14.0
 deepspeed==0.8.3
-trl @ git+https://github.com/lvwerra/trl.git#egg=trl-0.4.1
+trl
 sentencepiece
-transformers @ git+https://github.com/huggingface/transformers@c612628045822f909020f7eb6784c79700813eda
+transformers>=4.31.0
 flask
 flask_cors
 icetk
 cpm_kernels==1.0.11
 evaluate==0.4.0
 scikit-learn==1.2.2
-lm-eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@e47e01beea79cfe87421e2dac49e64d499c240b4
+lm-eval
 dill<0.3.5
-bitsandbytes==0.38.1
+bitsandbytes>=0.40.0
 pydantic<=1.10.9
 gradio

--- a/scripts/run_finetune_with_qlora_save_aggregated_weights.sh
+++ b/scripts/run_finetune_with_qlora_save_aggregated_weights.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Please run this script under ${project_id} in project directory of
+
+# Parses arguments
+model_name_or_path=meta-llama/Llama-2-13b-hf
+dataset_path=/home/paperspace/LMFlow/alpaca/train
+output_dir=output_models/finetune
+deepspeed_args="--master_port=11000"
+
+while [[ $# -ge 1 ]]; do
+  key="$1"
+  case ${key} in
+    -m|--model_name_or_path)
+      model_name_or_path="$2"
+      shift
+      ;;
+    -d|--dataset_path)
+      dataset_path="$2"
+      shift
+      ;;
+    -o|--output_model_path)
+      output_dir="$2"
+      shift
+      ;;
+    --deepspeed_args)
+      deepspeed_args="$2"
+      shift
+      ;;
+    *)
+      echo "error: unknown option \"${key}\"" 1>&2
+      exit 1
+  esac
+  shift
+done
+
+# Finetune
+exp_id=finetune_with_lora
+project_dir=$(cd "$(dirname $0)"/..; pwd)
+log_dir=${project_dir}/log/${exp_id}
+mkdir -p ${output_dir} ${log_dir}
+
+deepspeed ${deepspeed_args} \
+  examples/finetune.py \
+    --model_name_or_path ${model_name_or_path} \
+    --dataset_path ${dataset_path} \
+    --output_dir ${output_dir} --overwrite_output_dir \
+    --num_train_epochs 0.01 \
+    --learning_rate 1e-4 \
+    --block_size 512 \
+    --per_device_train_batch_size 1 \
+    --use_qlora 1 \
+    --save_aggregated_lora 1\
+    --deepspeed configs/ds_config_zero2.json \
+    --fp16 \
+    --run_name ${exp_id} \
+    --validation_split_percentage 0 \
+    --logging_steps 20 \
+    --do_train \
+    --ddp_timeout 72000 \
+    --save_steps 5000 \
+    --dataloader_num_workers 1 \
+    | tee ${log_dir}/train.log \
+    2> ${log_dir}/train.err

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
 try:
   gpu_state = subprocess.check_output(["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"])
   if b"A100" or b"A40" in gpu_state:
-    subprocess.call(["pip", "install", "flash-attn==2.0.2"])
+    subprocess.call(["pip", "install", "flash-attn==2.0.4"])
 except:
   pass

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -171,13 +171,13 @@ class ModelArguments:
     )
     bits: int = field(
         default=4,
-        choices=[4,8],
-        metadata={"help": "The number of bits for quantization."},
+        metadata={"help": "The number of bits for quantization.",
+                  "choices": [4, 8],},
     )
     quant_type: str = field(
         default='nf4',
-        choices=['nf4', 'fp4'],
-        metadata={"help": "The quantization type for quantization."},
+        metadata={"help": "The quantization type for quantization.",
+                  "choices": ["nf4", "fp4"],},
     )
     double_quant: bool = field(
         default=True,

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -167,13 +167,13 @@ class ModelArguments:
     )
     use_qlora: bool = field(
         default=False,
-        metadata="Whether to use qlora.",
+        metadata={"help": "Whether to use qlora."},
     )
     bits: int = field(
         default=4,
         metadata={"help": "The number of bits for quantization.",
                   "choices": [4, 8],},
-    )
+    )1
     quant_type: str = field(
         default='nf4',
         metadata={"help": "The quantization type for quantization.",

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -165,6 +165,24 @@ class ModelArguments:
         default=False,
         metadata={"help": "Whether to lora."},
     )
+    use_qlora: bool = field(
+        default=False,
+        metadata="Whether to use qlora.",
+    )
+    bits: int = field(
+        default=4,
+        choices=[4,8],
+        metadata={"help": "The number of bits for quantization."},
+    )
+    quant_type: str = field(
+        default='nf4',
+        choices=['nf4', 'fp4'],
+        metadata={"help": "The quantization type for quantization."},
+    )
+    double_quant: bool = field(
+        default=True,
+        metadata={"help": "Whether to use double quantization."},
+    )
     lora_r: int = field(
         default=8,
         metadata={"help": "the rank of the lora parameters. The smaller lora_r is , the fewer parameters lora has."},

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -173,7 +173,7 @@ class ModelArguments:
         default=4,
         metadata={"help": "The number of bits for quantization.",
                   "choices": [4, 8],},
-    )1
+    )
     quant_type: str = field(
         default='nf4',
         metadata={"help": "The quantization type for quantization.",

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -151,6 +151,14 @@ class ModelArguments:
             )
         },
     )
+    trust_remote_code : bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to trust remote code when loading model."
+            )
+        },
+    )
     torch_dtype: Optional[str] = field(
         default=None,
         metadata={

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -30,6 +30,7 @@ from peft import (
     TaskType,
     get_peft_config,
     get_peft_model,
+    prepare_model_for_kbit_training
 )
 
 import torch
@@ -277,7 +278,11 @@ class HFDecoderModel(DecoderModel, Tunable):
                     revision=model_args.model_revision,
                     use_auth_token=True if model_args.use_auth_token else None,
                     torch_dtype=torch_dtype,
+                    device_map={"":0},
                 )
+                if model_args.use_qlora:
+                    model.gradient_checkpointing_enable()
+                    model = prepare_model_for_kbit_training(model)
             else:
                 model = AutoModelForCausalLM.from_config(config)
                 n_params = sum(dict((p.data_ptr(), p.numel()) for p in model.parameters()).values())

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -705,7 +705,7 @@ class HFDecoderModel(DecoderModel, Tunable):
             trust_remote_code = self.model_args.trust_remote_code,
         )
     
-        self.backend_model = get_peft_model(self.backend_model_full, tempdir)
+        self.backend_model = PeftModel.from_pretrained(self.backend_model_full, tempdir)
         shutil.rmtree(tempdir)
 
     def save(self, dir, save_full_model=False, *args, **kwargs):

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -259,7 +259,7 @@ class HFDecoderModel(DecoderModel, Tunable):
                     
         if tune_strategy == 'normal':
             if model_args.model_name_or_path:
-                compute_dtype = (torch.float16 if torch_dtype=='fp16' else (torch.bfloat16 if torch_dtype=='bf16' else torch.float32))
+                compute_dtype = (torch.float16 if torch_dtype=='float16' else (torch.bfloat16 if torch_dtype=='bfloat16' else torch.float32))
                 device_map = "auto"
                 if os.environ.get('LOCAL_RANK') is not None:
                     local_rank = int(os.environ.get('LOCAL_RANK','0'))

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -273,7 +273,7 @@ class HFDecoderModel(DecoderModel, Tunable):
                     model_args.model_name_or_path,
                     from_tf=bool(".ckpt" in model_args.model_name_or_path),
                     config=config,
-                    quantization_config=quant_config if args.use_qlora else None,
+                    quantization_config=quant_config if model_args.use_qlora else None,
                     cache_dir=model_args.cache_dir,
                     revision=model_args.model_revision,
                     use_auth_token=True if model_args.use_auth_token else None,

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -279,6 +279,7 @@ class HFDecoderModel(DecoderModel, Tunable):
                     use_auth_token=True if model_args.use_auth_token else None,
                     torch_dtype=torch_dtype,
                     device_map={"":0},
+                    trust_remote_code = model_args.trust_remote_code,
                 )
                 if model_args.use_qlora:
                     model.gradient_checkpointing_enable()

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -693,7 +693,7 @@ class HFDecoderModel(DecoderModel, Tunable):
             local_rank = int(os.environ.get('LOCAL_RANK','0'))
             device_map = {'': local_rank}
 
-        self.backend_model_full = AutoModelForCausalLM(
+        self.backend_model_full = AutoModelForCausalLM.from_pretrained(
             self.model_args.model_name_or_path,
             from_tf=bool(".ckpt" in self.model_args.model_name_or_path),
             config=config,

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -259,7 +259,7 @@ class HFDecoderModel(DecoderModel, Tunable):
                     
         if tune_strategy == 'normal':
             if model_args.model_name_or_path:
-                compute_dtype = (torch.float16 if torch_dtype=='float16' else (torch.bfloat16 if torch_dtype=='bfloat16' else torch.float32))
+                compute_dtype = torch_dtype
                 device_map = "auto"
                 if os.environ.get('LOCAL_RANK') is not None:
                     local_rank = int(os.environ.get('LOCAL_RANK','0'))

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -674,6 +674,7 @@ class HFDecoderModel(DecoderModel, Tunable):
     def get_peft_without_qlora(self):
         tempdir = Path.cwd()/'TEMP'
         tempdir = tempdir.resolve()
+        tempdir = str(tempdir)
 
         self.get_backend_model().save_pretrained(tempdir)
 


### PR DESCRIPTION
I have added arguments under model_args to enable QLoRA support. Namely arguments are:

-  use_qlora: bool (default: False)
-  bits: int = (default 4, wtih choices between 4,8)
-  quant_type: str = 'nf4' default with optional choice of 'fp4'
-  double_quant: bool = (default: True)

Is model_args.use_qlora is set to 1/True, it also sets model_arga.lora to True so the entire pipeline works.