### PR TITLE
fix bugs in requirements.txt since previous one can cause errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ wandb==0.14.0
 deepspeed==0.10.0
 trl==0.5.0
 sentencepiece
-transformers>=4.31.0
+transformers>=4.31.0,<4.35.0
 flask
 flask_cors
 icetk


### PR DESCRIPTION
Hello!

In transformers 4.35.0, the developers deleted names `is_fairscale_available` and `default_hp_search_backend` from `transformers.integrations`, which causes errors since LMFlow actively tries to find the names in those locations.

As a quick workaround, I propose to change the requirements.txt and add a condition `transformers<4.35.0`.