### PR TITLE
Update dependency for `transformers`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ wandb==0.14.0
 deepspeed==0.10.0
 trl==0.5.0
 sentencepiece
-transformers>=4.31.0,<4.38.0
+transformers>=4.31.0
 flask
 flask_cors
 icetk


### PR DESCRIPTION
- The mistral issue in transformers==4.38.x no longer appears in latest 4.39.2