### PR TITLE
[Model Support] Qwen2 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ An extensible, convenient, and efficient toolbox for finetuning large machine le
 | [LLaMA-2](https://huggingface.co/meta-llama) | `llama2` ([Link](https://optimalscale.github.io/LMFlow/examples/supported_conversation_template.html#llama-2)) |
 | [LLaMA-3](https://huggingface.co/meta-llama) | `llama3` ([Link](https://optimalscale.github.io/LMFlow/examples/supported_conversation_template.html#llama-3)) |
 | [Phi-3](https://huggingface.co/microsoft) | `phi3` ([Link](https://optimalscale.github.io/LMFlow/examples/supported_conversation_template.html#phi-3)) |
-| [Qwen1.5](https://huggingface.co/Qwen) | `qwen2` ([Link](https://optimalscale.github.io/LMFlow/examples/supported_conversation_template.html#qwen-2)) |
+| [Qwen1.5 <br> Qwen2](https://huggingface.co/Qwen) | `qwen2` ([Link](https://optimalscale.github.io/LMFlow/examples/supported_conversation_template.html#qwen-2)) |
 | [Yi](https://huggingface.co/01-ai) | `chatml` ([Link](https://optimalscale.github.io/LMFlow/examples/supported_conversation_template.html#yi)) |
 | [Yi-1.5](https://huggingface.co/01-ai) | `yi1_5` ([Link](https://optimalscale.github.io/LMFlow/examples/supported_conversation_template.html#yi-15)) |
 | [Zephyr](https://huggingface.co/HuggingFaceH4) | `zephyr` ([Link](https://optimalscale.github.io/LMFlow/examples/supported_conversation_template.html#zephyr)) |

--- a/docs/source/examples/supported_conversation_template.md
+++ b/docs/source/examples/supported_conversation_template.md
@@ -325,6 +325,9 @@ The conversation template for Mixtral 8x7B is slightly different from the templa
 
 
 ## Qwen-2
+
+(Also Qwen-1.5)
+
 **With a system message**
 ```
 <|im_start|>system\n{{system_message}}<|im_end|>\n<|im_start|>user\n{{user_message_0}}<|im_end|>\n
@@ -346,7 +349,7 @@ The conversation template for Mixtral 8x7B is slightly different from the templa
 ```
 
 **jinja template**  
-[[Reference](https://huggingface.co/Qwen/Qwen1.5-72B/blob/93bac0d1ae83d50c43b1793e2d74a00dc43a4c36/tokenizer_config.json#L31)]
+[[Reference](https://huggingface.co/Qwen/Qwen2-72B-Instruct/blob/1af63c698f59c4235668ec9c1395468cb7cd7e79/tokenizer_config.json#L31)]
 ```
 {% for message in messages %}{% if loop.first and messages[0]['role'] != 'system' %}{{ '<|im_start|>system\nYou are a helpful assistant<|im_end|>\n' }}{% endif %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}
 ```


### PR DESCRIPTION
# Description
Support Qwen2 models.
Only docs are updated, since the pipeline requirements are the same as Qwen1.5.


# Pipeline Tests
1. Full-Finetune
![full](https://github.com/OptimalScale/LMFlow/assets/79436959/6221f816-19c5-468c-82dc-f5af5c1c4a71)

2 LoRA
![lora](https://github.com/OptimalScale/LMFlow/assets/79436959/03643ae8-6f2f-446f-9064-c58154a62ab1)


# Known Issue

> **Note: This isn't a bug in LMFlow, but we will add a logger notification ASAP to notify users when they might trigger this bug.** 

When do lora (or other peft tuning that uses `peft` library) first and saved model at a dir, say, A, and then do another finetuning work that also specifies the same `output_dir` A, pipeline will fail to update the model card, since `Qwen2ForCausalLM` doesn't have attribute `.create_or_update_model_card()`. **But this will not affect the model saving.** 

Bug logi:
1. Finetune with `PeftTrainer` and save leads to a modelcard with `library_name = 'peft'`.
2. When do anyother finetune with same `output_dir`, since
https://github.com/huggingface/transformers/blob/bdf36dcd48106a4a0278ed7f3cc26cd65ab7b066/src/transformers/trainer.py#L4114, `os.path.exists(model_card_filepath)` is `True`, and then `is_peft_library` is `True`.
3. At https://github.com/huggingface/transformers/blob/bdf36dcd48106a4a0278ed7f3cc26cd65ab7b066/src/transformers/trainer.py#L4143, transformers will do `.create_or_update_model_card()`, which `Qwen2ForCausalLM` doesn't have.

![qwenbug](https://github.com/OptimalScale/LMFlow/assets/79436959/13cb0a6f-1fd3-4dad-ab97-fb0e3207eaf3)


**We strongly recommend to use different `output_dir` for every finetuning work to avoid unexpected issues like the one above.**

