### PR TITLE
[usability] Change dataset check method

### DIFF
--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -492,6 +492,10 @@ class DatasetArguments:
     conversation_template: str
         a string representing the template for conversation datasets.
 
+    dataset_cache_dir: str
+        a string representing the path to the dataset cache directory. Useful when the default cache dir
+        (`~/.cache/huggingface/datasets`) has limited space.
+
     The class also includes some additional parameters that can be used to configure the dataset further, such as `overwrite_cache`,
     `validation_split_percentage`, `preprocessing_num_workers`, `disable_group_texts`, `demo_example_in_prompt`, `explanation_in_prompt`,
     `keep_linebreaks`, and `prompt_structure`.
@@ -608,6 +612,11 @@ class DatasetArguments:
         default=None,
         metadata={"help": "The template for conversation datasets."}
     )
+    dataset_cache_dir: Optional[str] = field(
+        default=None,
+        metadata={"help": ("The path to the dataset cache directory. Useful when the "
+                           "default cache dir (`~/.cache/huggingface/datasets`) has limited space.")}
+    )
 
     def __post_init__(self):
         if self.streaming:
@@ -622,6 +631,9 @@ class DatasetArguments:
             if self.validation_file is not None:
                 extension = self.validation_file.split(".")[-1]
                 assert extension in ["csv", "json", "txt"], "`validation_file` should be a csv, a json or a txt file."
+                
+        if self.skip_dataset_check:
+            logger.warning("Skip dataset check is enabled. Make sure the datasets are in the correct format.")
 
 
 @dataclass

--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -631,9 +631,6 @@ class DatasetArguments:
             if self.validation_file is not None:
                 extension = self.validation_file.split(".")[-1]
                 assert extension in ["csv", "json", "txt"], "`validation_file` should be a csv, a json or a txt file."
-                
-        if self.skip_dataset_check:
-            logger.warning("Skip dataset check is enabled. Make sure the datasets are in the correct format.")
 
 
 @dataclass

--- a/src/lmflow/datasets/dataset.py
+++ b/src/lmflow/datasets/dataset.py
@@ -95,7 +95,7 @@ class Dataset:
             # check if the dataset is in the correct format and get the dataset type (text_only, text2text, etc.)
             self._check_hf_json_format(data_files)
             # Load the dataset using the HuggingFace dataset library
-            print('loading datasets')
+            logger.info('Loading datasets')
             extensions = "json"
             raw_dataset = load_dataset(
                 extensions,

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -234,7 +234,6 @@ class HFDecoderModel(DecoderModel, HFModelMixin, Tunable):
                 "load_from_cache_file": not data_args.overwrite_cache,
                 "desc": "Running tokenizer on dataset",
                 "new_fingerprint": fingerprint,
-                "max_length": data_args.block_size,
             }
 
         if data_args.block_size < self.tokenizer.model_max_length:

--- a/src/lmflow/models/hf_decoder_model.py
+++ b/src/lmflow/models/hf_decoder_model.py
@@ -117,7 +117,7 @@ class HFDecoderModel(DecoderModel, HFModelMixin, Tunable):
 
     def tokenize(
         self, 
-        dataset, 
+        dataset: Dataset, 
         add_special_tokens=True, 
         *args, 
         **kwargs
@@ -234,8 +234,14 @@ class HFDecoderModel(DecoderModel, HFModelMixin, Tunable):
                 "load_from_cache_file": not data_args.overwrite_cache,
                 "desc": "Running tokenizer on dataset",
                 "new_fingerprint": fingerprint,
+                "max_length": data_args.block_size,
             }
 
+        if data_args.block_size < self.tokenizer.model_max_length:
+            logger.warning(
+                f"block_size {data_args.block_size} < model_max_length {self.tokenizer.model_max_length}, "
+                "use block_size for maximum tokenized sequence length."
+            )
         tokenized_datasets = raw_datasets.map(
             tokenize_fn,
             batched=True,

--- a/src/lmflow/pipeline/finetuner.py
+++ b/src/lmflow/pipeline/finetuner.py
@@ -33,7 +33,7 @@ from transformers.utils import (
 import numpy as np
 
 import lmflow.optim.optimizers as optim
-from lmflow.args import OptimizerNames
+from lmflow.args import OptimizerNames, DatasetArguments, ModelArguments, FinetunerArguments
 from lmflow.datasets.dataset import Dataset
 from lmflow.pipeline.base_tuner import BaseTuner
 from lmflow.pipeline.utils.peft_trainer import PeftTrainer, PeftSavingCallback
@@ -64,7 +64,14 @@ class Finetuner(BaseTuner):
         Keyword arguments.
 
     """
-    def __init__(self, model_args, data_args, finetuner_args, *args, **kwargs):
+    def __init__(
+        self, 
+        model_args: ModelArguments, 
+        data_args: DatasetArguments, 
+        finetuner_args: FinetunerArguments, 
+        *args, 
+        **kwargs
+    ):
 
         self.model_args = model_args
         self.data_args = data_args

--- a/src/lmflow/tokenization/hf_decoder_model.py
+++ b/src/lmflow/tokenization/hf_decoder_model.py
@@ -27,13 +27,10 @@ def blocking(
     padding_side: str,
     truncation_side: str='right',
 ) -> Dict:
-    block_size_warning_num = 0
     num_example = len(token_dict[list(token_dict.keys())[0]])
     for i in range(num_example):
         max_length = min(block_size, model_max_length)
         pad_length = max_length - len(token_dict["input_ids"][i])
-        if block_size < model_max_length:
-            block_size_warning_num += 1
         if pad_length < 0:
             # Truncates too long samples
             for key in ["input_ids", "attention_mask", "labels"]:
@@ -72,13 +69,6 @@ def blocking(
                 raise ValueError(
                     f"padding_side should be either 'right' or 'left', got {padding_side}"
                 )
-    if block_size_warning_num > 0:
-        logger.warning(
-            f"There are {block_size_warning_num} of {num_example} samples where"
-            f"block_size {block_size} < model_max_length"
-            f" {model_max_length}, use block_size"
-            " for maximum tokenized sequence length"
-        )
         
     return token_dict
 

--- a/src/lmflow/tokenization/hf_text_regression_model.py
+++ b/src/lmflow/tokenization/hf_text_regression_model.py
@@ -28,14 +28,11 @@ def blocking_paired(
     padding_side: str,
     truncation_side: str='right',
 ) -> Dict:
-    block_size_warning_num = 0
     num_example = len(token_dict[list(token_dict.keys())[0]])
     for i in range(num_example):
         for column_name in column_names:
             max_length = min(block_size, model_max_length)
             pad_length = max_length - len(token_dict[f"input_ids_{column_name}"][i])
-            if block_size < model_max_length:
-                block_size_warning_num += 1
             if pad_length < 0:
                 # Truncates too long samples
                 for key in [f"input_ids_{column_name}", f"attention_mask_{column_name}"]:
@@ -68,13 +65,6 @@ def blocking_paired(
                     raise ValueError(
                         f"padding_side should be either 'right' or 'left', got {padding_side}"
                     )
-    if block_size_warning_num > 0:
-        logger.warning(
-            f"There are {block_size_warning_num} of {num_example} samples where"
-            f" block_size {block_size} < model_max_length"
-            f" {model_max_length}, use block_size"
-            " for maximum tokenized sequence length"
-        )
         
     return token_dict
 
@@ -87,13 +77,10 @@ def blocking(
     padding_side: str,
     truncation_side: str='right',
 ) -> Dict:
-    block_size_warning_num = 0
     num_example = len(token_dict[list(token_dict.keys())[0]])
     for i in range(num_example):
         max_length = min(block_size, model_max_length)
         pad_length = max_length - len(token_dict["input_ids"][i])
-        if block_size < model_max_length:
-            block_size_warning_num += 1
         if pad_length < 0:
             # Truncates too long samples
             for key in ["input_ids", "attention_mask", "labels"]:
@@ -132,13 +119,6 @@ def blocking(
                 raise ValueError(
                     f"padding_side should be either 'right' or 'left', got {padding_side}"
                 )
-    if block_size_warning_num > 0:
-        logger.warning(
-            f"There are {block_size_warning_num} of {num_example} samples where"
-            f" block_size {block_size} < model_max_length"
-            f" {model_max_length}, use block_size"
-            " for maximum tokenized sequence length"
-        )
         
     return token_dict
 
@@ -151,15 +131,12 @@ def blocking_text_to_textlist(
     padding_side: str,
     truncation_side: str='right',
 ) -> Dict:
-    block_size_warning_num = 0
     num_example = len(token_dict[list(token_dict.keys())[0]])
     max_length = min(block_size, model_max_length)
     
     for example_idx in range(num_example):
         for content_idx in range(len(token_dict["input_ids"][example_idx])):
             pad_length = max_length - len(token_dict["input_ids"][example_idx][content_idx])
-            if block_size < model_max_length:
-                block_size_warning_num += 1
             if pad_length < 0:
                 # Truncates too long samples
                 if truncation_side == 'right':
@@ -185,13 +162,6 @@ def blocking_text_to_textlist(
                     raise ValueError(
                         f"padding_side should be either 'right' or 'left', got {padding_side}"
                     )
-    if block_size_warning_num > 0:
-        logger.warning(
-            f"There are {block_size_warning_num} of {num_example} samples where"
-            f" block_size {block_size} < model_max_length"
-            f" {model_max_length}, use block_size"
-            " for maximum tokenized sequence length"
-        )
         
     return token_dict
 

--- a/src/lmflow/utils/debug/profiler.py
+++ b/src/lmflow/utils/debug/profiler.py
@@ -1,0 +1,37 @@
+import time
+import pprint
+
+
+class Timer:
+    def __init__(self, name):
+        self.name = name
+        self.runtimes = {}
+        self.runtimes_readable = {}
+
+    def start(self, tag):
+        self.runtimes[tag] = {"start": time.time()}
+
+    def end(self, tag):
+        self.runtimes[tag]["end"] = time.time()
+        self.runtimes[tag]["elapsed"] = self.runtimes[tag]["end"] - self.runtimes[tag]["start"]
+        
+    def get_runtime(self, tag):
+        return self.runtimes[tag]["elapsed"]
+    
+    def show(self):
+        self._to_readable()
+        pprint.pprint(self.runtimes_readable)
+        
+    def _to_readable(self):
+        for tag, runtime in self.runtimes.items():
+            self.runtimes_readable[tag] = {"start": time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(runtime["start"]))}
+            self.runtimes_readable[tag]["end"] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(runtime["end"]))
+            self.runtimes_readable[tag]["elapsed"] = round(runtime["elapsed"], 5)
+            
+
+if __name__ == "__main__":
+    timer = Timer("profiler")
+    timer.start("main")
+    time.sleep(1)
+    timer.end("main")
+    timer.show()


### PR DESCRIPTION
1. Change how lmflow verify the dataset format.
2. Users can now specify dataset cache dir by `--dataset_cache_dir xxx`, which is useful when tokenizing a big dataset and the default dir has limited space.
3. Add a simple profiler for dev uses.

## Tests
![image](https://github.com/user-attachments/assets/babc205e-13b5-420e-8726-4be9db47cd59)
> ![image](https://github.com/user-attachments/assets/6712015b-4559-4aa6-8749-93429ec60fb9)
> ![image](https://github.com/user-attachments/assets/adecfc62-9315-4c2f-afd6-733fd5224393)
> 81 json files, each contains ~2,600,000 instances. After tokenization, the cache file takes ~1.3T disk space.

![image](https://github.com/user-attachments/assets/dd2fcb86-5e7b-46d1-854e-73d5155e6141)
> Tested on normal conversation dataset, works fine.

![image](https://github.com/user-attachments/assets/1a5c2cc1-c50f-48d5-ae99-00dd9b712e99)
> Compare w/ main branch. Note: temporarily add random control (torch and np seed) thus git reports `finetuner.py` as modified.
