### PR TITLE
refactor: improve environment and dependency compatibility

### DIFF
--- a/src/lmflow/args.py
+++ b/src/lmflow/args.py
@@ -569,7 +569,15 @@ class DatasetArguments:
         default=False, metadata={"help": "Whether to train on prompt for conversation datasets such as ShareGPT."}
     )
     conversation_template: Optional[str] = field(
-        default=None, metadata={"help": "The template for conversation datasets."}
+        default=None,
+        metadata={
+            "help": (
+                "The template for conversation datasets. Supports LMFlow preset names "
+                "(e.g. llama3, qwen2_5, deepseek_v3) and special values "
+                "`tokenizer` / `hf_auto` to use tokenizer.chat_template "
+                "(`tokenizer` is strict; `hf_auto` falls back to LMFlow default when unavailable)."
+            )
+        },
     )
     dataset_cache_dir: Optional[str] = field(
         default=None,

--- a/src/lmflow/pipeline/auto_pipeline.py
+++ b/src/lmflow/pipeline/auto_pipeline.py
@@ -4,20 +4,24 @@
 from lmflow.pipeline.evaluator import Evaluator
 from lmflow.pipeline.finetuner import Finetuner
 from lmflow.pipeline.inferencer import Inferencer
-from lmflow.pipeline.sglang_inferencer import SGLangInferencer
 from lmflow.pipeline.rm_inferencer import RewardModelInferencer
 from lmflow.pipeline.rm_tuner import RewardModelTuner
-from lmflow.utils.versioning import is_package_version_at_least, is_ray_available, is_trl_available, is_vllm_available
+from lmflow.utils.versioning import is_package_version_at_least, is_ray_available, is_sglang_available, is_trl_available, is_vllm_available
 
 PIPELINE_MAPPING = {
     "evaluator": Evaluator,
     "finetuner": Finetuner,
     "inferencer": Inferencer,
-    "sglang_inferencer": SGLangInferencer,
     "rm_inferencer": RewardModelInferencer,
     "rm_tuner": RewardModelTuner,
 }
 PIPELINE_NEEDS_EXTRAS = []
+
+if is_sglang_available():
+    from lmflow.pipeline.sglang_inferencer import SGLangInferencer
+    PIPELINE_MAPPING["sglang_inferencer"] = SGLangInferencer
+else:
+    PIPELINE_NEEDS_EXTRAS.append("sglang_inferencer")
 
 if not is_package_version_at_least("transformers", "4.35.0"):
     from lmflow.pipeline.raft_aligner import RaftAligner

--- a/src/lmflow/pipeline/finetuner.py
+++ b/src/lmflow/pipeline/finetuner.py
@@ -17,9 +17,11 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint
-from transformers.utils import (
-    send_example_telemetry,
-)
+
+try:
+    from transformers.utils import send_example_telemetry
+except ImportError:
+    send_example_telemetry = None
 
 from lmflow.args import DatasetArguments, FinetunerArguments, ModelArguments
 from lmflow.datasets.dataset import Dataset
@@ -73,7 +75,8 @@ class Finetuner(BaseTuner):
         # Sending telemetry. Tracking the example usage helps us better
         # allocate resources to maintain them. The information sent is the one
         # passed as arguments along with your Python/PyTorch versions.
-        send_example_telemetry("run_clm", model_args, data_args)
+        if send_example_telemetry is not None:
+            send_example_telemetry("run_clm", model_args, data_args)
 
         # Setup logging
         logging.basicConfig(

--- a/src/lmflow/tokenization/hf_decoder_model.py
+++ b/src/lmflow/tokenization/hf_decoder_model.py
@@ -142,9 +142,16 @@ def conversation_tokenize_function(
                 if data_args.train_on_prompt:
                     labels = encoded_conversation["input_ids"]
                 else:
+                    assistant_masks = encoded_conversation.get("assistant_masks", None)
+                    if assistant_masks is None:
+                        raise RuntimeError(
+                            "Tokenizer chat template path requires `assistant_masks` for label masking when "
+                            "`train_on_prompt=False`. Please upgrade transformers/tokenizer support, "
+                            "or use an LMFlow conversation template."
+                        )
                     labels = [
                         encoded_conversation["input_ids"][index] if mask == 1 else -100
-                        for index, mask in enumerate(encoded_conversation["assistant_masks"])
+                        for index, mask in enumerate(assistant_masks)
                     ]
 
                 token_dict["input_ids"][i].extend(encoded_conversation["input_ids"])

--- a/src/lmflow/utils/versioning.py
+++ b/src/lmflow/utils/versioning.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 import sys
 from pathlib import Path
-from typing import Union
+from typing import Union, List, Tuple
 
 import pkg_resources
 
@@ -29,7 +29,7 @@ def _is_package_available(package_name: str, skippable: bool = False):
                 raise e
 
 
-def _is_packages_available(packages: Union[list[str], list[tuple[str, bool]]]):
+def _is_packages_available(packages: Union[List[str], List[Tuple[str, bool]]]):
     if isinstance(packages[0], str):
         return all([_is_package_available(package) for package in packages])
     elif isinstance(packages[0], tuple):

--- a/src/lmflow/utils/versioning.py
+++ b/src/lmflow/utils/versioning.py
@@ -1,10 +1,11 @@
 import importlib
 import logging
 import sys
+from importlib import metadata
 from pathlib import Path
 from typing import Union, List, Tuple
 
-import pkg_resources
+from packaging.version import Version, InvalidVersion
 
 logger = logging.getLogger(__name__)
 
@@ -40,10 +41,10 @@ def _is_packages_available(packages: Union[List[str], List[Tuple[str, bool]]]):
 
 def is_package_version_at_least(package_name, min_version):
     try:
-        package_version = pkg_resources.get_distribution(package_name).version
-        if pkg_resources.parse_version(package_version) < pkg_resources.parse_version(min_version):
+        package_version = metadata.version(package_name)
+        if Version(package_version) < Version(min_version):
             return False
-    except pkg_resources.DistributionNotFound:
+    except (metadata.PackageNotFoundError, InvalidVersion):
         return False
     return True
 


### PR DESCRIPTION
### Summary
This PR addresses several dependency drift issues that currently prevent LMFlow from running in Python 3.10+ and older stable environments (Python 3.9) and improved conversation template for modern chat models. 

### Changes
1. **Python 3.9 Backward Compatibility**: Replaced PEP 604 union types (`|`) with `typing.Union` and updated generic aliases in `protocol.py` and `versioning.py`. This restores support for Python 3.9.
2. **Dependency Decoupling**: Implemented a lazy loading pattern for `sglang_inferencer` in `auto_pipeline.py` to make new user easily run a simple fine-tuning happy path
3. **Upstream API Adaptation**: Wrapped `transformers.utils.send_example_telemetry` in a `try-except` block to handle its removal in `transformers >= 4.41.0`.
4. Standardized optional dependency checks within `versioning.py`.
5. **Deprecation Cleanup**: migrated version checks from deprecated `pkg_resources` to `importlib.metadata` +` packaging.version` in ` versioning.py`. This removes repeated startup deprecation warnings
6. *Conversation template improvements*: added  `conversation_template=tokenizer` which requires `tokenizer.chat_template` and `conversation_template=hf_auto` which uses tokenizer template if available, otherwise falls back to LMFlow default template. If no template is specified, the system now prefers the tokenizer-native template when available to ensure perfect formatting for modern models