### PR TITLE
feat: add training stability guards and fix transformers 5.2.0 compat…

### DIFF
--- a/src/lmflow/pipeline/finetuner.py
+++ b/src/lmflow/pipeline/finetuner.py
@@ -107,7 +107,7 @@ class Finetuner(BaseTuner):
         if (
             os.path.isdir(finetuner_args.output_dir)
             and finetuner_args.do_train
-            and not finetuner_args.overwrite_output_dir
+            and not getattr(finetuner_args, "overwrite_output_dir", False)
         ):
             last_checkpoint = get_last_checkpoint(finetuner_args.output_dir)
             if last_checkpoint is None and len(os.listdir(finetuner_args.output_dir)) > 0:
@@ -321,6 +321,31 @@ class Finetuner(BaseTuner):
             if data_args.max_train_samples is not None:
                 max_train_samples = min(len(train_dataset), data_args.max_train_samples)
                 train_dataset = train_dataset.select(range(max_train_samples))
+
+        if getattr(finetuner_args, "bf16", False) and not torch.cuda.is_bf16_supported():
+            logger.warning(
+                "Hardware does not support bfloat16 (requires Ampere architecture or newer). "
+                "Automatically falling back to fp16 to prevent CUDA crashes."
+            )
+            finetuner_args.bf16 = False
+            finetuner_args.fp16 = True
+
+        if getattr(finetuner_args, "gradient_checkpointing", False):
+            backend_model = model.get_backend_model()
+            if hasattr(backend_model, "config") and getattr(backend_model.config, "use_cache", False):
+                logger.info("Gradient checkpointing is enabled. Automatically setting use_cache=False for the model.")
+                backend_model.config.use_cache = False
+
+        backend_model = model.get_backend_model()
+        tokenizer = model.get_tokenizer()
+        if hasattr(backend_model, "get_input_embeddings") and tokenizer is not None:
+            embeddings = backend_model.get_input_embeddings()
+            if embeddings is not None and len(tokenizer) > embeddings.weight.shape[0]:
+                logger.warning(
+                    f"Tokenizer vocabulary size ({len(tokenizer)}) is greater than model embedding dimension "
+                    f"({embeddings.weight.shape[0]}). Resizing model embeddings to prevent CUDA out-of-bounds crashes."
+                )
+                backend_model.resize_token_embeddings(len(tokenizer))
 
         # Initialize our Trainer
         training_args = finetuner_args

--- a/src/lmflow/pipeline/utils/raft_trainer.py
+++ b/src/lmflow/pipeline/utils/raft_trainer.py
@@ -3389,7 +3389,7 @@ class RaftTrainer:
         Initializes a git repo in `self.args.hub_model_id`.
         Args:
             at_init (`bool`, *optional*, defaults to `False`):
-                Whether this function is called before any training or not. If `self.args.overwrite_output_dir` is
+                Whether this function is called before any training or not. If `getattr(self.args, "overwrite_output_dir", False)` is
                 `True` and `at_init` is `True`, the path to the repo (which is `self.args.output_dir`) might be wiped
                 out.
         """
@@ -3407,7 +3407,7 @@ class RaftTrainer:
         try:
             self.repo = Repository(self.args.output_dir, clone_from=repo_name, token=self.args.hub_token)
         except OSError:
-            if self.args.overwrite_output_dir and at_init:
+            if getattr(self.args, "overwrite_output_dir", False) and at_init:
                 # Try again after wiping output_dir
                 shutil.rmtree(self.args.output_dir)
                 self.repo = Repository(self.args.output_dir, clone_from=repo_name, token=self.args.hub_token)

--- a/tests/pipeline/test_sglang_infernecer.py
+++ b/tests/pipeline/test_sglang_infernecer.py
@@ -1,5 +1,8 @@
 import numpy as np
 import pytest
+
+pytest.importorskip("sglang")
+
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.server_args import ServerArgs
 


### PR DESCRIPTION
Description

This PR introduces several hardware-aware safeguards to prevent common crashes during training and improves compatibility with newer library versions.

Improvements:

- BF16 Auto-Fallback: Automatically falls back to fp16 if bf16 is requested on unsupported hardware (pre-Ampere GPUs), preventing cryptic CUDA errors.
- Gradient Checkpointing Guard: Automatically disables use_cache when gradient checkpointing is active to prevent known training conflicts.
- Vocabulary Mismatch Guard: Automatically resizes model embeddings if the tokenizer's vocabulary exceeds the model's dimension (essential when using custom chat templates).

- Library Compatibility:
Fixed AttributeError for overwrite_output_dir appearing in transformers >= 5.2.0.
Added pytest.importorskip for sglang to prevent test collection crashes in environments without sglang.