### PR TITLE
fix: clarify setup hints, pin pyarrow, fix NLL error message

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 packaging
 numpy
 datasets==3.6.0
+pyarrow>=15.0.0
 tokenizers>=0.13.3
 peft>=0.10.0
 torch>=2.0.1

--- a/src/lmflow/__init__.py
+++ b/src/lmflow/__init__.py
@@ -10,6 +10,12 @@ from lmflow import args, datasets, models, pipeline, utils
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.27.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/language-modeling/requirements.txt")
+require_version(
+    "datasets>=1.8.0",
+    (
+        "To fix: from the LMFlow repository root, run `pip install -r requirements.txt` "
+        "or `pip install -e .`"
+    ),
+)
 
 __all__ = ["args", "datasets", "models", "pipeline", "utils"]

--- a/src/lmflow/pipeline/evaluator.py
+++ b/src/lmflow/pipeline/evaluator.py
@@ -38,6 +38,11 @@ from lmflow.utils.versioning import is_deepspeed_available
 os.environ["TOKENIZERS_PARALLELISM"] = "false"  # To avoid warnings about parallelism in tokenizers
 
 
+def _nll_unsupported_dataset_message(dataset_type: str) -> str:
+    """Error text when NLL evaluation does not support this dataset type."""
+    return f"{dataset_type} typed datasets are not supported in negative log likelihood evaluation"
+
+
 class Evaluator(BasePipeline):
     """
     Initializes the `Evaluator` class with given arguments.
@@ -543,7 +548,7 @@ class Evaluator(BasePipeline):
                             f" {current_output_nll}"
                         )
                     else:
-                        raise NotImplementedError("f{dataset.get_type()} typed datasets are not supported")
+                        raise NotImplementedError(_nll_unsupported_dataset_message(dataset.get_type()))
 
                 if end_loc == seq_len:
                     break

--- a/tests/pipeline/test_evaluator_messages.py
+++ b/tests/pipeline/test_evaluator_messages.py
@@ -1,0 +1,12 @@
+"""Regression tests for evaluator user-facing error messages."""
+
+import unittest
+
+from lmflow.pipeline.evaluator import _nll_unsupported_dataset_message
+
+
+class TestEvaluatorMessages(unittest.TestCase):
+    def test_nll_unsupported_dataset_message_includes_type(self):
+        msg = _nll_unsupported_dataset_message("conversation")
+        self.assertIn("conversation", msg)
+        self.assertNotIn("f{", msg)


### PR DESCRIPTION
- When `datasets` is below the minimum version, the fix hint now points users to the repository root (`pip install -r requirements.txt` or `pip install -e .`) instead of the stale path `examples/pytorch/language-modeling/requirements.txt`.
- Add `pyarrow>=15.0.0` to match Hugging Face datasets 3.6.0 dependency metadata
- Fix the unsupported-type branch in NLL evaluation so the message includes the actual dataset type (and remove the mistaken literal `f{...}` text). Added `_nll_unsupported_dataset_message()` for a clear, testable string.